### PR TITLE
Fix docblocks in accordion-item

### DIFF
--- a/src/accordion-item/render.php
+++ b/src/accordion-item/render.php
@@ -2,9 +2,9 @@
 /**
  * Accordion Item
  *
- * @param array     $attributes Block attributes.
- * @param string    $content    Block default content.
- * @param \WP_Block $block      Block instance.
+ * @var array     $attributes Block attributes.
+ * @var string    $content    Block default content.
+ * @var \WP_Block $block      Block instance.
  *
  * @package pixelalbatross/accordion-block
  */
@@ -44,7 +44,7 @@ $aria_label_close = sprintf(
 				/**
 				 * Fires before the accordion item title.
 				 *
-				 * @param string {title} Accordion item title.
+				 * @param string $title Accordion item title.
 				 */
 				do_action( 'pixelalbatross_accordion_block_before_item_title', $attributes['title'] );
 				?>
@@ -55,9 +55,9 @@ $aria_label_close = sprintf(
 
 				<?php
 				/**
-				 * Fires after the accordion item title
+				 * Fires after the accordion item title.
 				 *
-				 * @param string {title} Accordion item title.
+				 * @param string $title Accordion item title.
 				 */
 				do_action( 'pixelalbatross_accordion_block_after_item_title', $attributes['title'] );
 				?>


### PR DESCRIPTION
- use [`@var` tag](https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/var.html#var) to define global variable types
- fix `@param` tag usage, `{title}` is for JavaScript
- add a period

@s3rgiosan